### PR TITLE
FIX Possible crash when updating from old version

### DIFF
--- a/Logmatic/LMUserDefaultsPersistence.m
+++ b/Logmatic/LMUserDefaultsPersistence.m
@@ -28,27 +28,35 @@ static LMUserDefaultsPersistence * sSharedUserDefaultsPersistence;
 #pragma mark - LMPersistence
 
 - (void)replaceLogs:(NSArray<NSDictionary *> *)logs {
+    NSUserDefaults *userDefaults = [NSUserDefaults standardUserDefaults];
+    
     NSData *data = nil;
-    if (logs) {
+    if (logs && logs.count > 0) {
         data = [NSKeyedArchiver archivedDataWithRootObject:logs];
+        [userDefaults setObject:data forKey:kUserDefaultsLogsKey];
+    } else {
+        [userDefaults removeObjectForKey:kUserDefaultsLogsKey];
     }
-    NSUserDefaults * userDefaults = [NSUserDefaults standardUserDefaults];
-    [userDefaults setObject:data forKey:kUserDefaultsLogsKey];
+    
     [userDefaults synchronize];
 }
 
 - (void)addLogs:(NSArray<NSDictionary *> *)logs {
-    NSArray<NSDictionary *> * existingLogs = [self savedLogs];
-    NSArray<NSDictionary *> * mergedLogs = [NSArray mergeSafelyArray:logs withArray:existingLogs];
+    NSArray<NSDictionary *> *existingLogs = [self savedLogs];
+    NSArray<NSDictionary *> *mergedLogs = [NSArray mergeSafelyArray:logs withArray:existingLogs];
     [self replaceLogs:mergedLogs];
 }
 
-- (nullable NSArray<NSDictionary *> *)savedLogs {
-    NSData *data = [[NSUserDefaults standardUserDefaults] objectForKey:kUserDefaultsLogsKey];
-    if (data) {
-        return [NSKeyedUnarchiver unarchiveObjectWithData:data];
+- (NSArray<NSDictionary *> *)savedLogs {
+    NSUserDefaults *userDefaults = [NSUserDefaults standardUserDefaults];
+    
+    id object = [userDefaults objectForKey:kUserDefaultsLogsKey];
+    NSArray<NSDictionary *> *logs = nil;
+    
+    if ([object isKindOfClass:[NSData class]]) {
+        logs = [NSKeyedUnarchiver unarchiveObjectWithData:(NSData *)object];
     }
-    return nil;
+    return logs;
 }
 
 - (void)deleteAllLogs {


### PR DESCRIPTION
FIX Possible crash when updating from old version that does not use KeyedArchiver/KeyedUnArchiver.

If you where using and old version, that was writing values directly to NSUserDefaults, and migrate to the last version that uses NSData from NSKeyedArchiver as value the app crashes.
